### PR TITLE
fix: resolve mobile tab bar clipping and add missing CSS layout tokens

### DIFF
--- a/.claude/apple-design-context.md
+++ b/.claude/apple-design-context.md
@@ -51,6 +51,9 @@
 - [x] Bottom tab bar for mobile — `src/components/mobile-nav.tsx` (Today, Chat, Routines, Settings; 4 items; 11px labels; amber active)
 - [x] `viewportFit: cover` — `layout.tsx` viewport export
 - [x] `display-mode: standalone` CSS override — `globals.css`
+- [x] `--pwa-nav-nudge` fixed — was `-12px` in standalone (clipping tab bar 12px below viewport), now `0px`
+- [x] CSS tokens added — `--top-bar-height: 3.5rem`, `--sidebar-width: 14rem` with `@theme inline` aliases (`min-h-top-bar`, `w-sidebar`)
+- [x] Token violations resolved — `sidebar.tsx` uses `w-sidebar`, `header.tsx` uses `min-h-top-bar`
 
 ## Accessibility
 - **Target Level**: Baseline

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,10 +56,14 @@
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
   --spacing-tab-bar: var(--tab-bar-height);
+  --spacing-top-bar: var(--top-bar-height);
+  --spacing-sidebar: var(--sidebar-width);
 }
 
 :root {
   --tab-bar-height: 3.5rem;
+  --top-bar-height: 3.5rem;
+  --sidebar-width: 14rem;
   --clarity-amber: oklch(0.769 0.188 70.08);
   --clarity-amber-foreground: oklch(0.145 0 0);
   --clarity-amber-muted: oklch(0.769 0.188 70.08 / 12%);
@@ -300,10 +304,6 @@
 :root {
   --safari-toolbar-h: 0px;
   --pwa-nav-nudge: 0px;
-}
-
-html[data-standalone] {
-  --pwa-nav-nudge: -12px;
 }
 
 /* Safe area utilities — used by mobile nav and body clearance */

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -81,7 +81,7 @@ export function Header() {
     .slice(0, 2)
 
   return (
-    <header className="flex min-h-14 items-center justify-between border-b px-4 pt-[env(safe-area-inset-top)]">
+    <header className="flex min-h-top-bar items-center justify-between border-b px-4 pt-[env(safe-area-inset-top)]">
       <LiveClock />
       <div className="flex items-center gap-2">
         <Button

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -24,7 +24,7 @@ export function Sidebar() {
   }, [pathname])
 
   return (
-    <aside className="hidden md:flex w-56 flex-col border-r px-3 py-4">
+    <aside className="hidden md:flex w-sidebar flex-col border-r px-3 py-4">
       <div className="mb-6 flex items-center gap-2 px-2">
         <Image src="/pwa/manifest-icon-192.maskable.png" alt="Clarity" width={28} height={28} className="rounded-md" />
         <span className="font-semibold text-lg">Clarity</span>


### PR DESCRIPTION
## Summary

- **Critical bug fixed:** `--pwa-nav-nudge: -12px` in standalone PWA mode was positioning the mobile tab bar at `bottom: -12px`, clipping the tab labels off-screen (the "dock pushed down" issue)
- Added missing CSS layout primitives `--top-bar-height` and `--sidebar-width` to `:root` with Tailwind v4 `@theme inline` aliases
- Replaced hardcoded `w-56` (sidebar) and `min-h-14` (header) with token-driven classes `w-sidebar` and `min-h-top-bar`

## Test plan

- [ ] Install Clarity as PWA on iPhone, verify tab bar is fully visible and not clipped
- [ ] Open in Safari browser mode, verify tab bar positions correctly above Safari toolbar
- [ ] Verify sidebar width unchanged on desktop/iPad (still 14rem / 224px)
- [ ] Verify header height unchanged (still 3.5rem minimum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile tab bar clipping in PWA standalone mode and standardizes layout sizing with new CSS tokens. Sidebar and header now use token-driven classes.

- **Bug Fixes**
  - Removed the standalone override that set --pwa-nav-nudge to -12px, which clipped the tab bar off-screen.

- **Refactors**
  - Added --top-bar-height (3.5rem) and --sidebar-width (14rem) in :root with Tailwind v4 @theme inline aliases (min-h-top-bar, w-sidebar).
  - Replaced min-h-14 with min-h-top-bar in header.tsx and w-56 with w-sidebar in sidebar.tsx.

<sup>Written for commit ef26ba586d898bb2a95cf0f44ea5ec87a1d61196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

