### PR TITLE
fix: add overflow hidden to html/body to prevent double browser scrollbar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Key vars: `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, `BETTER_AUTH_SECRET`, `GOOGL
 | Turso schema drift | Use Turso HTTP API for targeted DDL when `drizzle-kit push` has conflicts |
 | AI context freshness | Coach must inject fresh context on every turn (not cache from first message) |
 | `stripHtml()` for AI | Always strip Tiptap HTML to plain text before sending to AI models |
+| Double browser scrollbar | Fixed-viewport layout needs `overflow: hidden` on `html, body` — `overscroll-behavior: none` only prevents bounce, not the body scrollbar track |
 
 ## Database Tables
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -234,6 +234,7 @@
   }
   html,
   body {
+    overflow: hidden;
     overscroll-behavior: none;
     -webkit-tap-highlight-color: transparent;
   }


### PR DESCRIPTION
## Summary

- Adds `overflow: hidden` to `html, body` in `globals.css` to eliminate the double scrollbar on desktop (macOS with always-visible scrollbars or mouse input)
- Documents the pattern in `CLAUDE.md` Gotchas so future sessions don't repeat the mistake

## Root cause

`overscroll-behavior: none` prevents bounce/rubber-band effects but does **not** prevent the browser from rendering a scrollbar track on the body. When the app uses a fixed-viewport layout (`h-dvh overflow-hidden` outer div), the body itself should never scroll — `overflow: hidden` enforces this.

## Test plan

- [ ] Open `/tasks` in Chrome on macOS with "Always show scroll bars" (System Preferences → Appearance)
- [ ] Confirm only one scrollbar is visible (the `main` content area), not two
- [ ] Confirm auth pages (login/signup) still render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the double browser scrollbar on desktop by setting overflow: hidden on html and body. Also documents the gotcha in CLAUDE.md so we don’t repeat it.

<sup>Written for commit 1814bb94a7ea9f0fb9b41fde83a52c0c853da50a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

