### PR TITLE
fix: scope overflow hidden to html only

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -232,9 +232,11 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    overflow: hidden;
+  }
   html,
   body {
-    overflow: hidden;
     overscroll-behavior: none;
     -webkit-tap-highlight-color: transparent;
   }


### PR DESCRIPTION
## Summary

Fixes the regression from PR #4 where `overflow: hidden` on both `html` and `body` broke all inner scroll containers.

`overflow: hidden` on `body` creates a new BFC that breaks `h-full` height propagation for any page that uses a flex/grid height chain (chat, tasks, email, etc.). All scroll containers inside `main` stopped working.

The correct scope: only `html` needs `overflow: hidden`. The `html` element owns the viewport scrollbar — setting it there eliminates the double browser scrollbar without touching body's layout behavior.

## Test plan

- [ ] Verify tasks page scrolls vertically
- [ ] Verify chat page conversation list scrolls, suggestion chips scroll horizontally
- [ ] Verify no double scrollbar remains on desktop macOS with "Always show scroll bars"

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped overflow: hidden to the html element only to fix broken inner scroll containers caused by body overflow, while still avoiding the double browser scrollbar. Restores scrolling on pages that use flex/grid height chains (chat, tasks, email).

<sup>Written for commit b2874508ad78137a0f503190c1c07247452a97e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

