### PR TITLE
feat: UI sprint — grid layouts, search/filter, graph polish

### DIFF
--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useMemo } from "react"
 import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { TasksFilterBar } from "@/components/tasks/tasks-filter-bar"
 import { TaskGroup } from "@/components/tasks/task-group"
+import { TaskCardEnhanced } from "@/components/tasks/task-card-enhanced"
 import { CreateTaskModal } from "@/components/tasks/create-task-modal"
 import { SubtaskList } from "@/components/tasks/subtask-list"
 import {
@@ -16,11 +17,16 @@ import {
   groupTasksByDate,
 } from "@/types/task"
 
+const GRID_PAGE_SIZE = 9
+
 export default function TasksPage() {
   const [tab, setTab] = useState("active")
   const [tasks, setTasks] = useState<TaskItem[]>([])
   const [loading, setLoading] = useState(true)
   const [createOpen, setCreateOpen] = useState(false)
+  const [search, setSearch] = useState("")
+  const [view, setView] = useState<"list" | "grid">("list")
+  const [gridPage, setGridPage] = useState(1)
   const [filters, setFilters] = useState<TaskFilters>({
     source: "all",
     priority: "all",
@@ -46,11 +52,50 @@ export default function TasksPage() {
     } finally {
       setLoading(false)
     }
-  }, [tab, filters])
+  }, [tab, filters.source, filters.priority, filters.dateFilter])
 
   useEffect(() => {
     fetchTasks()
   }, [fetchTasks])
+
+  // Reset grid page when any filter/search changes
+  useEffect(() => {
+    setGridPage(1)
+  }, [search, filters.project, filters.source, filters.priority, filters.dateFilter, tab, view])
+
+  // Extract unique project names from task metadata
+  const projects = useMemo(() => {
+    const names = new Set<string>()
+    for (const t of tasks) {
+      try {
+        const meta = JSON.parse(t.metadata) as Record<string, unknown>
+        if (typeof meta.projectName === "string") names.add(meta.projectName)
+      } catch { /* ignore */ }
+    }
+    return Array.from(names).sort()
+  }, [tasks])
+
+  // Client-side filter: search text + project
+  const displayTasks = useMemo(() => {
+    return tasks.filter((t) => {
+      if (search && !t.title.toLowerCase().includes(search.toLowerCase())) return false
+      if (filters.project !== "all") {
+        try {
+          const meta = JSON.parse(t.metadata) as Record<string, unknown>
+          if (meta.projectName !== filters.project) return false
+        } catch {
+          return false
+        }
+      }
+      return true
+    })
+  }, [tasks, search, filters.project])
+
+  const grouped = groupTasksByDate(displayTasks)
+
+  // Grid pagination
+  const gridTasks = displayTasks.slice(0, gridPage * GRID_PAGE_SIZE)
+  const hasMoreGrid = displayTasks.length > gridTasks.length
 
   async function handleComplete(id: string) {
     await fetch(`/api/tasks/${id}/complete`, { method: "POST" })
@@ -73,58 +118,86 @@ export default function TasksPage() {
     )
   }
 
-  const grouped = groupTasksByDate(tasks)
-
   return (
     <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h1 className="text-lg font-semibold">Tasks</h1>
-          <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
-            <Plus className="size-3.5" />
-            New Task
-          </Button>
-        </div>
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Tasks</h1>
+        <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
+          <Plus className="size-3.5" />
+          New Task
+        </Button>
+      </div>
 
-        <TasksFilterBar filters={filters} onChange={setFilters} />
+      <TasksFilterBar
+        filters={filters}
+        onChange={setFilters}
+        search={search}
+        onSearchChange={setSearch}
+        view={view}
+        onViewChange={setView}
+        projects={projects}
+      />
 
-        <Tabs value={tab} onValueChange={setTab}>
-          <TabsList className="grid w-full grid-cols-3">
-            <TabsTrigger value="active">Active</TabsTrigger>
-            <TabsTrigger value="completed">Completed</TabsTrigger>
-            <TabsTrigger value="hidden">Hidden</TabsTrigger>
-          </TabsList>
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="active">Active</TabsTrigger>
+          <TabsTrigger value="completed">Completed</TabsTrigger>
+          <TabsTrigger value="hidden">Hidden</TabsTrigger>
+        </TabsList>
 
-          <TabsContent value={tab} className="mt-4 space-y-6">
-            {loading ? (
-              <TasksLoadingSkeleton />
-            ) : tasks.length === 0 ? (
-              <TasksEmptyState tab={tab} />
-            ) : (
-              DATE_GROUP_ORDER.map((group) => (
-                <TaskGroup
-                  key={group}
-                  group={group as DateGroup}
-                  tasks={grouped[group as DateGroup]}
-                  onComplete={tab === "active" ? handleComplete : undefined}
-                  onHide={tab === "active" ? handleHide : undefined}
-                  onReschedule={tab === "active" ? handleReschedule : undefined}
-                  renderSubtasks={(taskId, sourceId, source) => (
-                    <SubtaskList
-                      taskId={taskId}
-                      sourceId={sourceId}
-                      source={source}
-                    />
-                  )}
-                />
-              ))
-            )}
-          </TabsContent>
-        </Tabs>
-        <CreateTaskModal
-          open={createOpen}
-          onClose={() => setCreateOpen(false)}
-          onSuccess={fetchTasks}
-        />
+        <TabsContent value={tab} className="mt-4 space-y-6">
+          {loading ? (
+            <TasksLoadingSkeleton />
+          ) : displayTasks.length === 0 ? (
+            <TasksEmptyState tab={tab} hasSearch={search.length > 0} />
+          ) : view === "grid" ? (
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                {gridTasks.map((task) => (
+                  <TaskCardEnhanced
+                    key={task.id}
+                    task={task}
+                    onComplete={tab === "active" ? handleComplete : undefined}
+                    onHide={tab === "active" ? handleHide : undefined}
+                    onReschedule={tab === "active" ? handleReschedule : undefined}
+                    renderSubtasks={(taskId, sourceId, source) => (
+                      <SubtaskList taskId={taskId} sourceId={sourceId} source={source} />
+                    )}
+                  />
+                ))}
+              </div>
+              {hasMoreGrid && (
+                <button
+                  onClick={() => setGridPage((p) => p + 1)}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Show {Math.min(GRID_PAGE_SIZE, displayTasks.length - gridTasks.length)} more
+                </button>
+              )}
+            </div>
+          ) : (
+            DATE_GROUP_ORDER.map((group) => (
+              <TaskGroup
+                key={group}
+                group={group as DateGroup}
+                tasks={grouped[group as DateGroup]}
+                onComplete={tab === "active" ? handleComplete : undefined}
+                onHide={tab === "active" ? handleHide : undefined}
+                onReschedule={tab === "active" ? handleReschedule : undefined}
+                renderSubtasks={(taskId, sourceId, source) => (
+                  <SubtaskList taskId={taskId} sourceId={sourceId} source={source} />
+                )}
+              />
+            ))
+          )}
+        </TabsContent>
+      </Tabs>
+
+      <CreateTaskModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSuccess={fetchTasks}
+      />
     </div>
   )
 }
@@ -148,15 +221,17 @@ function TasksLoadingSkeleton() {
   )
 }
 
-function TasksEmptyState({ tab }: { tab: string }) {
+function TasksEmptyState({ tab, hasSearch }: { tab: string; hasSearch: boolean }) {
   return (
     <div className="text-center py-12 text-muted-foreground">
       <p className="text-sm">
-        {tab === "active"
-          ? "No active tasks. Create one or connect Todoist in Settings."
-          : tab === "hidden"
-            ? "No hidden tasks."
-            : "No completed tasks yet."}
+        {hasSearch
+          ? "No tasks match your search."
+          : tab === "active"
+            ? "No active tasks. Create one or connect Todoist in Settings."
+            : tab === "hidden"
+              ? "No hidden tasks."
+              : "No completed tasks yet."}
       </p>
     </div>
   )

--- a/src/components/dashboard/life-context-strip.tsx
+++ b/src/components/dashboard/life-context-strip.tsx
@@ -20,9 +20,23 @@ interface Props {
   snapshot: FinancialSnap | null
 }
 
+const URGENCY_ORDER = ["critical", "escalated", "active", "monitoring", "resolved"] as const
+
+const URGENCY_STYLES: Record<string, string> = {
+  critical: "bg-destructive/10 text-destructive border-destructive/20",
+  escalated: "bg-warning/10 text-warning border-warning/20",
+  active: "bg-muted text-foreground border-border",
+  monitoring: "bg-muted/60 text-muted-foreground border-border",
+  resolved: "bg-muted/40 text-muted-foreground/60 border-border",
+}
+
+const PAGE_SIZE = 6
+
 export function LifeContextStrip({ items, snapshot }: Props) {
   const criticalItems = items.filter((i) => i.urgency === "critical")
   const [open, setOpen] = useState(criticalItems.length > 0)
+  const [filter, setFilter] = useState("all")
+  const [page, setPage] = useState(1)
 
   if (items.length === 0 && !snapshot) return null
 
@@ -30,6 +44,16 @@ export function LifeContextStrip({ items, snapshot }: Props) {
     snapshot && snapshot.monthlyBurnCents > 0
       ? (snapshot.bankBalanceCents / snapshot.monthlyBurnCents).toFixed(1)
       : null
+
+  const presentLevels = URGENCY_ORDER.filter((u) => items.some((i) => i.urgency === u))
+  const filtered = filter === "all" ? items : items.filter((i) => i.urgency === filter)
+  const visible = filtered.slice(0, page * PAGE_SIZE)
+  const hasMore = filtered.length > visible.length
+
+  function handleFilter(value: string) {
+    setFilter(value)
+    setPage(1)
+  }
 
   return (
     <div className="rounded-md border border-border bg-muted/20 text-sm">
@@ -57,23 +81,64 @@ export function LifeContextStrip({ items, snapshot }: Props) {
           </span>
         )}
       </button>
+
       {open && (
-        <div className="border-t border-border px-4 py-3 space-y-2">
-          {items.map((item) => (
-            <div key={item.id} className="flex items-start gap-2">
-              <span
+        <div className="border-t border-border px-4 py-3 space-y-3">
+          {presentLevels.length > 1 && (
+            <div className="flex flex-wrap gap-1.5">
+              <button
+                onClick={() => handleFilter("all")}
                 className={cn(
-                  "mt-0.5 shrink-0 rounded px-2 py-0.5 text-[11px] font-semibold uppercase",
-                  item.urgency === "critical"
-                    ? "bg-destructive/10 text-destructive"
-                    : "bg-muted text-foreground",
+                  "rounded-full px-2.5 py-0.5 text-[11px] font-medium transition-colors",
+                  filter === "all"
+                    ? "bg-foreground text-background"
+                    : "bg-muted text-muted-foreground hover:text-foreground",
                 )}
               >
-                {item.urgency}
-              </span>
-              <span className="text-sm">{item.title}</span>
+                All
+              </button>
+              {presentLevels.map((level) => (
+                <button
+                  key={level}
+                  onClick={() => handleFilter(level)}
+                  className={cn(
+                    "rounded-full border px-2.5 py-0.5 text-[11px] font-medium capitalize transition-colors",
+                    filter === level
+                      ? URGENCY_STYLES[level]
+                      : "border-transparent bg-muted text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {level}
+                </button>
+              ))}
             </div>
-          ))}
+          )}
+
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {visible.map((item) => (
+              <div
+                key={item.id}
+                className={cn(
+                  "rounded-md border px-3 py-2",
+                  URGENCY_STYLES[item.urgency] ?? "bg-muted border-border",
+                )}
+              >
+                <span className="block text-[10px] font-semibold uppercase tracking-wide opacity-60 mb-0.5">
+                  {item.urgency}
+                </span>
+                <span className="text-xs leading-snug">{item.title}</span>
+              </div>
+            ))}
+          </div>
+
+          {hasMore && (
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Show {Math.min(PAGE_SIZE, filtered.length - visible.length)} more
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/components/life-context/context-graph.tsx
+++ b/src/components/life-context/context-graph.tsx
@@ -5,6 +5,7 @@ import {
   ReactFlow,
   ReactFlowProvider,
   Background,
+  BackgroundVariant,
   Controls,
   useNodesState,
   useEdgesState,
@@ -40,7 +41,9 @@ function getLayoutedElements(nodes: Node[], edges: Edge[]) {
 // ─── Node styling by type + severity ─────────────────────────────────────────
 
 const BASE_NODE_STYLE: React.CSSProperties = {
-  color: "#111827",
+  color: "var(--color-foreground)",
+  background: "var(--color-muted)",
+  border: "1.5px solid var(--color-border)",
   fontSize: 12,
   fontWeight: 500,
   padding: "6px 12px",
@@ -52,24 +55,30 @@ function getNodeStyle(type: string, severity?: string): React.CSSProperties {
   if (type === "context") {
     switch (severity) {
       case "critical":
-        return { ...BASE_NODE_STYLE, background: "#fee2e2", border: "2px solid #ef4444" }
+        return {
+          ...BASE_NODE_STYLE,
+          background: "color-mix(in oklch, var(--color-destructive) 12%, var(--color-background))",
+          border: "1.5px solid color-mix(in oklch, var(--color-destructive) 55%, transparent)",
+        }
       case "escalated":
-        return { ...BASE_NODE_STYLE, background: "#ffedd5", border: "2px solid #fb923c" }
-      case "active":
-        return { ...BASE_NODE_STYLE, background: "#fefce8", border: "2px solid #facc15" }
+        return {
+          ...BASE_NODE_STYLE,
+          background: "color-mix(in oklch, var(--clarity-amber) 12%, var(--color-background))",
+          border: "1.5px solid color-mix(in oklch, var(--clarity-amber) 55%, transparent)",
+        }
       default:
-        return { ...BASE_NODE_STYLE, background: "#f0fdf4", border: "2px solid #4ade80" }
+        return { ...BASE_NODE_STYLE }
     }
   }
   switch (type) {
     case "task":
-      return { ...BASE_NODE_STYLE, background: "#eff6ff", border: "2px solid #60a5fa" }
+      return { ...BASE_NODE_STYLE, border: "1.5px solid oklch(0.65 0.15 250)" }
     case "email":
-      return { ...BASE_NODE_STYLE, background: "#faf5ff", border: "2px solid #c084fc" }
+      return { ...BASE_NODE_STYLE, border: "1.5px solid oklch(0.65 0.18 300)" }
     case "event":
-      return { ...BASE_NODE_STYLE, background: "#eef2ff", border: "2px solid #818cf8" }
+      return { ...BASE_NODE_STYLE, border: "1.5px solid oklch(0.65 0.14 175)" }
     default:
-      return { ...BASE_NODE_STYLE, background: "#f9fafb", border: "2px solid #9ca3af" }
+      return { ...BASE_NODE_STYLE }
   }
 }
 
@@ -91,7 +100,7 @@ function buildFlowElements(apiNodes: GraphNode[], apiEdges: GraphEdge[]) {
     id: e.id,
     source: e.source,
     target: e.target,
-    style: { stroke: "#94a3b8" },
+    style: { stroke: "var(--color-border)" },
   }))
 
   return getLayoutedElements(nodes, edges)
@@ -200,7 +209,13 @@ function ContextGraphInner() {
         fitView
         fitViewOptions={{ padding: 0.2 }}
       >
-        <Background />
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={20}
+          size={1.5}
+          color="#f59e0b"
+          style={{ opacity: 0.25 }}
+        />
         <Controls />
       </ReactFlow>
 

--- a/src/components/tasks/tasks-filter-bar.tsx
+++ b/src/components/tasks/tasks-filter-bar.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { Search, LayoutList, LayoutGrid } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
 import {
   Select,
   SelectContent,
@@ -12,57 +15,124 @@ import { TASK_SOURCES, SOURCE_LABELS, type TaskFilters } from "@/types/task"
 interface TasksFilterBarProps {
   filters: TaskFilters
   onChange: (filters: TaskFilters) => void
+  search: string
+  onSearchChange: (v: string) => void
+  view: "list" | "grid"
+  onViewChange: (v: "list" | "grid") => void
+  projects: string[]
 }
 
-export function TasksFilterBar({ filters, onChange }: TasksFilterBarProps) {
+export function TasksFilterBar({
+  filters,
+  onChange,
+  search,
+  onSearchChange,
+  view,
+  onViewChange,
+  projects,
+}: TasksFilterBarProps) {
   return (
-    <div className="flex flex-wrap gap-2">
-      <Select
-        value={filters.source}
-        onValueChange={(v) => onChange({ ...filters, source: v })}
-      >
-        <SelectTrigger className="w-[140px] h-8 text-xs">
-          <SelectValue placeholder="Source" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All sources</SelectItem>
-          {TASK_SOURCES.map((s) => (
-            <SelectItem key={s} value={s}>
-              {SOURCE_LABELS[s]}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div className="space-y-2">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
+        <Input
+          placeholder="Search tasks..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="pl-8 h-8 text-xs"
+        />
+      </div>
 
-      <Select
-        value={filters.priority}
-        onValueChange={(v) => onChange({ ...filters, priority: v })}
-      >
-        <SelectTrigger className="w-[130px] h-8 text-xs">
-          <SelectValue placeholder="Priority" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All priorities</SelectItem>
-          <SelectItem value="5">Urgent</SelectItem>
-          <SelectItem value="4">High</SelectItem>
-          <SelectItem value="3">Medium</SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="flex flex-wrap gap-2 items-center">
+        <Select
+          value={filters.source}
+          onValueChange={(v) => onChange({ ...filters, source: v })}
+        >
+          <SelectTrigger className="w-[140px] h-8 text-xs">
+            <SelectValue placeholder="Source" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sources</SelectItem>
+            {TASK_SOURCES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {SOURCE_LABELS[s]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-      <Select
-        value={filters.dateFilter ?? "all"}
-        onValueChange={(v) => onChange({ ...filters, dateFilter: v as TaskFilters["dateFilter"] })}
-      >
-        <SelectTrigger className="w-[130px] h-8 text-xs">
-          <SelectValue placeholder="Due date" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All dates</SelectItem>
-          <SelectItem value="today">Today</SelectItem>
-          <SelectItem value="week">This Week</SelectItem>
-          <SelectItem value="overdue">Overdue</SelectItem>
-        </SelectContent>
-      </Select>
+        <Select
+          value={filters.priority}
+          onValueChange={(v) => onChange({ ...filters, priority: v })}
+        >
+          <SelectTrigger className="w-[130px] h-8 text-xs">
+            <SelectValue placeholder="Priority" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All priorities</SelectItem>
+            <SelectItem value="5">Urgent</SelectItem>
+            <SelectItem value="4">High</SelectItem>
+            <SelectItem value="3">Medium</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.dateFilter ?? "all"}
+          onValueChange={(v) =>
+            onChange({ ...filters, dateFilter: v as TaskFilters["dateFilter"] })
+          }
+        >
+          <SelectTrigger className="w-[130px] h-8 text-xs">
+            <SelectValue placeholder="Due date" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All dates</SelectItem>
+            <SelectItem value="today">Today</SelectItem>
+            <SelectItem value="week">This Week</SelectItem>
+            <SelectItem value="overdue">Overdue</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {projects.length > 0 && (
+          <Select
+            value={filters.project}
+            onValueChange={(v) => onChange({ ...filters, project: v })}
+          >
+            <SelectTrigger className="w-[150px] h-8 text-xs">
+              <SelectValue placeholder="Project" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All projects</SelectItem>
+              {projects.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        <div className="ml-auto flex gap-1">
+          <Button
+            variant={view === "list" ? "secondary" : "ghost"}
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => onViewChange("list")}
+            aria-label="List view"
+          >
+            <LayoutList className="size-3.5" />
+          </Button>
+          <Button
+            variant={view === "grid" ? "secondary" : "ghost"}
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => onViewChange("grid")}
+            aria-label="Grid view"
+          >
+            <LayoutGrid className="size-3.5" />
+          </Button>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Today page context section**: vertical list → 2-3 col card grid with severity filter pills and pagination after 6 items
- **Tasks page**: adds search bar, Todoist project/category selector (auto-extracted from metadata), list/grid view toggle, and 9-per-page pagination in grid mode
- **Context graph**: replaces hardcoded pastel hex node colors with CSS variable-based colors (`color-mix`, `var(--color-foreground/muted/background)`) for full light/dark theme support; adds amber dot grid background pattern

## Test plan

- [ ] Today page: context section opens, cards render in grid, severity filter pills show only for present levels, pagination loads 6 more
- [ ] Tasks page: search filters by title, project dropdown appears for Todoist tasks, grid toggle shows 3-column layout, "Show N more" paginates
- [ ] Context graph: nodes render with correct theme-aware colors in both light and dark mode, amber dot grid visible in background
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds grid layouts, search/project filters, and a list/grid toggle with pagination across Today and Tasks. Also updates the context graph with theme-aware colors and a subtle dot background.

- **New Features**
  - Today page: context items now in a 2–3 column card grid with urgency filter pills (only for present levels) and pagination after 6 items.
  - Tasks page: added search bar, Todoist project selector (auto-extracted from metadata), list/grid view toggle, 9-per-page grid pagination, and clearer empty states.
  - Context graph: nodes use CSS variable colors (via color-mix) for full light/dark support; borders/edges respect theme; added amber dot grid background.

<sup>Written for commit 5dbaa44a6c2820a4078f67aa3a8847f5c8ca1243. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

