### PR TITLE
Replace archive with trash for dismissed Gmail messages

### DIFF
--- a/src/app/api/triage/[id]/route.ts
+++ b/src/app/api/triage/[id]/route.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db"
 import { triageQueue, tasks, lifeContextItems } from "@/lib/schema"
 import { eq, and } from "drizzle-orm"
 import { getTodoistIntegrationRow } from "@/lib/integrations/todoist"
-import { archiveGmailMessage } from "@/lib/integrations/gmail"
+import { trashGmailMessage } from "@/lib/integrations/gmail"
 import { decryptToken } from "@/lib/crypto"
 
 type Action = "approve" | "dismiss" | "push_to_context" | "complete"
@@ -98,7 +98,7 @@ export async function POST(
 
     if (item.source === "gmail" && item.sourceId) {
       try {
-        await archiveGmailMessage(session.user.id, item.sourceId)
+        await trashGmailMessage(session.user.id, item.sourceId)
       } catch {
         // Best-effort — item is already dismissed locally
       }

--- a/src/lib/integrations/gmail.ts
+++ b/src/lib/integrations/gmail.ts
@@ -277,3 +277,24 @@ export async function archiveGmailMessage(
     return { ok: false, error: msg }
   }
 }
+
+export async function trashGmailMessage(
+  userId: string,
+  gmailId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const gmail = await getAuthenticatedGmailClient(userId)
+  if (!gmail) {
+    return { ok: false, error: "Google not connected" }
+  }
+
+  try {
+    await gmail.users.messages.trash({
+      userId: "me",
+      id: gmailId,
+    })
+    return { ok: true }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: msg }
+  }
+}


### PR DESCRIPTION
## Summary
Changed the triage dismissal behavior for Gmail messages from archiving to trashing, providing a more destructive action that better aligns with user expectations for dismissed items.

## Changes
- Added new `trashGmailMessage()` function to `src/lib/integrations/gmail.ts` that moves messages to Gmail's trash folder
- Updated the triage API endpoint to call `trashGmailMessage()` instead of `archiveGmailMessage()` when dismissing Gmail-sourced items
- The new function follows the same error handling and authentication patterns as the existing `archiveGmailMessage()` function

## Implementation Details
- The `trashGmailMessage()` function uses the Gmail API's `users.messages.trash()` method
- Maintains consistent error handling with proper authentication checks and error message propagation
- The change is applied at the point where triage items are dismissed, ensuring all dismissed Gmail messages are trashed rather than archived

https://claude.ai/code/session_01MgmPeeYjQaNRCPJxLf5NzS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dismissed Gmail triage items now go to Trash instead of Archive. This prevents dismissed emails from reappearing in triage and better matches user expectations.

- **New Features**
  - Added trashGmailMessage() using Gmail users.messages.trash.
  - Updated the triage dismiss flow to use trash for Gmail items.
  - Reused existing auth and error handling; no scope changes needed.

<sup>Written for commit 7c37ffeee1c7bc5dcf44cc49964622135f3550d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

